### PR TITLE
Add Dockerfile so new users can quickly try out the language

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcc:latest
+
+RUN apt-get update && apt-get -y install llvm-dev
+RUN git clone https://github.com/c3d/xl.git
+WORKDIR xl
+RUN make install
+WORKDIR ..
+RUN mkdir app
+WORKDIR app
+ENTRYPOINT ["/usr/local/bin/xl", "-i", "/dev/stdin"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ the standard library in XL. You can replace these constructs if you
 want, or add your own. Adding a new kind of loop is not more difficult
 in XL than adding a function, and it uses the same syntax.
 
+* [Docker Quickstart](#docker-quickstart)
 * [Simple examples](#a-few-simple-examples)
 * [Dialects and use cases](#dialects-and-use-cases)
 * [If you come from another language](#if-you-come-from-another-language)
@@ -48,6 +49,17 @@ also available in [asciidoc format](docs/HANDBOOK.adoc) and
 **WARNING** This documentation, like the compiler, is work in progress
 and presently extremely messy, incomplete and inaccurate.
 
+
+## Docker Quickstart
+
+To quickly try out the intrepreter, install Docker and run the following commands:
+
+```
+docker build . -t xl
+docker run -i xl
+```
+
+(Note: to see output, you need to send an EOF signal using Control-D)
 
 ## A few simple examples
 


### PR DESCRIPTION
I decided to add a basic Dockerfile so new users can quickly try out the language without having to install dependencies. Currently, the Dockerfile starts the interpreter" (in quotes because it waits for EOF before outputing anything) and reads from stdin (so you need to send Control-D to see output). The Dockerfile does have a few issues from a reproducibility standpoint: since the Makefile references git-submodules, we need to clone the repo in the Dockerfile. This affects reproducibility as it will always use the latest commit and depends on internet .

Future work:
- Make the Docker file open a port to a web IDE.